### PR TITLE
Add Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ""
+labels: ""
+assignees: ""
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ""
+labels: ""
+assignees: ""
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the issue templates to standardize bug reports and feature requests, and to disable blank issues.

Standardization of issue templates:

* [`.github/ISSUE_TEMPLATE/bug_report.md`](diffhunk://#diff-185833cb26d7ac66a4d39042fd576a820c2c2c6d05ad18973bb9c7dce77267c5R1-R33): Added a new template for bug reports, including sections for describing the bug, steps to reproduce, expected behavior, screenshots, and additional context.
* [`.github/ISSUE_TEMPLATE/feature_request.md`](diffhunk://#diff-148870715557a13127284f8aeaa28002ed6b034268af13c5d030ab59fd078220R1-R19): Added a new template for feature requests, including sections for describing the problem, the desired solution, alternative solutions, and additional context.

Configuration changes:

* [`.github/ISSUE_TEMPLATE/config.yml`](diffhunk://#diff-1c0d972ee49103af56fd608a77a28e1eb12f6908f263f0f183d46868fdcd8ea2R1): Disabled the ability to create blank issues.