### PR TITLE
Add Markdown Link Checking

### DIFF
--- a/.github/other-configurations/.linkspector.yml
+++ b/.github/other-configurations/.linkspector.yml
@@ -1,0 +1,7 @@
+dirs:
+  - ./
+  - ./docs
+excludedFiles:
+  - ./CHANGELOG.md
+aliveStatusCodes:
+  - 200

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -31,3 +31,21 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           LINTER_RULES_PATH: .github/super-linter-configurations
           YAML_ERROR_ON_WARNING: true
+
+  check-markdown-links:
+    name: Check Markdown links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Check Markdown links
+        uses: UmbrellaDocs/action-linkspector@v1.2.4
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          config_file: .github/other-configurations/.linkspector.yml
+          reporter: github-pr-review
+          fail_on_error: true
+          filter_mode: nofilter


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to add a new GitHub Actions workflow for checking Markdown links and configuring the link checker tool. The most important changes include the addition of a new job in the GitHub Actions workflow and the configuration file for the link checker.

### New GitHub Actions Workflow:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R34-R51): Added a new job named `check-markdown-links` to check Markdown links using the `UmbrellaDocs/action-linkspector` GitHub Action.

### Configuration for Link Checker:

* [`.github/other-configurations/.linkspector.yml`](diffhunk://#diff-f9691f23ea6c4c34ecbaa23a98721e0aa3c7a94f2fcdd38f7b99fe863c5f6305R1-R7): Added configuration for the link checker tool, specifying directories to include, files to exclude, and valid status codes for alive links.