### PR TITLE
Add Zizmor Checking

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -49,3 +49,28 @@ jobs:
           reporter: github-pr-review
           fail_on_error: true
           filter_mode: nofilter
+
+  run-zizmor:
+    name: Check GitHub Actions with zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v4.2.0
+        with:
+          version: "latest"
+      - name: Run zizmor 🌈
+        run: uvx zizmor --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3.28.0
+        with:
+          sarif_file: results.sarif
+          category: zizmor


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new job to the GitHub Actions workflow in the `.github/workflows/code-checks.yml` file. The job is designed to check GitHub Actions using the `zizmor` tool.

Key changes include:

* **New job addition:**
  * [`run-zizmor`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R52-R76): Added a new job named `run-zizmor` to the workflow, which runs on `ubuntu-latest` and includes several steps to checkout the repository, install the latest version of `uv`, run `zizmor`, and upload the SARIF file.