### PR TITLE
Check Justfile Format

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -52,6 +52,20 @@ jobs:
           fail_on_error: true
           filter_mode: nofilter
 
+  check-justfile-format:
+    name: Check Justfile Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Just
+        uses: extractions/setup-just@v2
+      - name: Check Justfile Format
+        run: just format-check
+
   run-zizmor:
     name: Check GitHub Actions with zizmor
     runs-on: ubuntu-latest

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,36 @@
+# ------------------------------------------------------------------------------
+# Prettier
+# ------------------------------------------------------------------------------
+
+prettier-check:
+    prettier . --check
+
+prettier-format:
+    prettier . --check --write
+
+# ------------------------------------------------------------------------------
+# Justfile
+# ------------------------------------------------------------------------------
+
+format:
+    just --fmt --unstable
+
+format-check:
+    just --fmt --check --unstable
+
+# ------------------------------------------------------------------------------
+# gitleaks
+# ------------------------------------------------------------------------------
+
+gitleaks-detect:
+    gitleaks detect --source . > /dev/null
+
+# ------------------------------------------------------------------------------
+# Git Hooks
+# ------------------------------------------------------------------------------
+
+# Install pre commit hook to run on all commits
+install-git-hooks:
+    cp -f githooks/pre-commit .git/hooks/pre-commit
+    cp -f githooks/post-commit .git/hooks/post-commit
+    chmod ug+x .git/hooks/*


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new GitHub Actions job for checking the format of the Justfile and adds several commands to the `Justfile` for formatting and other tasks.

### GitHub Actions:

* Added a new job `check-justfile-format` to `.github/workflows/code-checks.yml` to ensure the Justfile is properly formatted. This job uses the `extractions/setup-just` action and runs `just format-check`.

### Justfile:

* Added commands for Prettier to check and format code (`prettier-check` and `prettier-format`).
* Added commands for Justfile formatting (`format` and `format-check`).
* Added a command for detecting secrets using `gitleaks` (`gitleaks-detect`).
* Added commands to install Git hooks for pre-commit and post-commit actions (`install-git-hooks`).