### PR TITLE
Add Lefthook Validate Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -91,6 +91,22 @@ jobs:
           sarif_file: results.sarif
           category: zizmor
 
+  lefthook-validate:
+    name: Lefthook Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5.3.1
+        with:
+          version: "latest"
+      - name: Run Lefthook Validate
+        run: uvx lefthook validate
+
   run-codeql-analysis:
     name: CodeQL Analysis
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new job to the GitHub Actions workflow to validate code using Lefthook. The key changes include adding a new job named `lefthook-validate` to the `.github/workflows/code-checks.yml` file.

New job added to GitHub Actions workflow:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R94-R109): Added a `lefthook-validate` job that checks out the repository, installs the latest version of `uv`, and runs `uvx lefthook validate`.