### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -44,7 +44,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.3.1
+        uses: UmbrellaDocs/action-linkspector@v1.3.2
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml
@@ -63,7 +63,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Just
-        uses: extractions/setup-just@v2
+        uses: extractions/setup-just@v3
       - name: Check Justfile Format
         run: just format-check
 
@@ -87,7 +87,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.10
+        uses: github/codeql-action/upload-sarif@v3.28.12
         with:
           sarif_file: results.sarif
           category: zizmor
@@ -120,10 +120,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.10
+        uses: github/codeql-action/init@v3.28.12
         with:
           languages: actions
           queries: security-and-quality
           config-file: .github/other-configurations/codeql-config.yml
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.10
+        uses: github/codeql-action/analyze@v3.28.12


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the `.github/workflows/code-checks.yml` file to ensure the latest versions of various GitHub Actions are being used. The updates improve the workflow by incorporating the latest features and fixes from these actions.

The most important changes include:

* Updated the `Check Markdown links` action to use version 1.3.2 of `UmbrellaDocs/action-linkspector`.
* Updated the `Set up Just` action to use version 3 of `extractions/setup-just`.
* Updated the `Upload SARIF file` action to use version 3.28.12 of `github/codeql-action/upload-sarif`.
* Updated the `Initialize CodeQL` and `Perform CodeQL Analysis` actions to use version 3.28.12 of `github/codeql-action/init` and `github/codeql-action/analyze`, respectively.