### PR TITLE
Update Dependabot Groups and Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,16 +2,19 @@ version: 2
 
 updates:
   - package-ecosystem: "github-actions"
-    directories:
-      - "/"
+    directory: "/"
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       github-actions:
+        applies-to: "version-updates"
         patterns:
           - "*"
+        exclude-patterns:
+          - "super-linter/*"
         update-types:
           - "patch"
           - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/dependabot.yml` configuration to streamline dependency updates by consolidating directories, adding timezone support, and refining update group rules.

### Dependabot configuration updates:

* Consolidated the `directories` field into a single `directory` field for simplicity. (`[.github/dependabot.ymlL5-R17](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L5-R17)`)
* Added a `timezone` field set to `"Europe/London"` to ensure scheduled updates occur at the correct local time. (`[.github/dependabot.ymlL5-R17](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L5-R17)`)
* Enhanced the `github-actions` group configuration:
  - Introduced the `applies-to` field with the value `"version-updates"` for targeted updates. (`[.github/dependabot.ymlL5-R17](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L5-R17)`)
  - Added `exclude-patterns` to ignore updates matching the `"super-linter/*"` pattern. (`[.github/dependabot.ymlL5-R17](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L5-R17)`)