### PR TITLE
Add Zizmor Configuration

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -44,7 +44,7 @@ lefthook-validate:
 
 # Run zizmor checking
 zizmor-check:
-    zizmor .
+    zizmor . --pedantic --persona=pedantic
 
 # ------------------------------------------------------------------------------
 # Pinact


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `lefthook-validate` configuration in the `Justfile` to enhance the rigor of the `zizmor-check` command.

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL47-R47): Modified the `zizmor-check` command to include the `--pedantic` flag and set the persona to `pedantic`, ensuring stricter validation during the check.