### PR TITLE
Bump Lefthook Minimum Version

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,5 @@
 # https://github.com/evilmartians/lefthook
-min_version: 1.11.13
+min_version: 1.11.14
 colors: true
 
 output:


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor update to the `lefthook.yml` configuration file. The change updates the minimum required version of Lefthook from `1.11.13` to `1.11.14`.
