### PR TITLE
Set Zizmor persona to auditor

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -44,11 +44,7 @@ lefthook-validate:
 
 # Run zizmor checking
 zizmor-check:
-    uvx zizmor . --persona=pedantic
-
-# Run zizmor checking with sarif output
-zizmor-check-sarif:
-    uvx zizmor . --persona=pedantic --format sarif > results.sarif
+    uvx zizmor . --persona=auditor
 
 # ------------------------------------------------------------------------------
 # Pinact


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a modification to the `Justfile` to update the `lefthook-validate:` configuration for running the `zizmor-check` command.

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL47-R47): Changed the `zizmor-check` persona from `pedantic` to `auditor` and removed the `zizmor-check-sarif` target, which previously generated SARIF output.
