### PR TITLE
Update Prek Freeze Command

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -97,7 +97,7 @@ prek-update:
 
 # Prek update hooks
 prek-update-hooks:
-    prek autoupdate
+    prek update --freeze
 
 prek-update-additional-dependencies:
     uv run --script https://raw.githubusercontent.com/JackPlowman/update-prek-additional-dependencies/refs/heads/main/update_prek_additional_dependencies.py
@@ -110,4 +110,3 @@ prek-update-additional-dependencies:
 update:
     just pinact-update
     just prek-update
-    just prek-update-additional-dependencies


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `Justfile` to modify the behavior of the `prek-update` and `update` tasks, primarily to improve control over dependency updates and streamline the update process.

**Dependency update process changes:**

* Changed the `prek-update-hooks` recipe to use `prek update --freeze` instead of `prek autoupdate`, which will prevent automatic updating of dependencies and instead freeze them at their current versions.

**Update workflow simplification:**

* Removed the call to `prek-update-additional-dependencies` from the `update` recipe, so additional dependencies are no longer updated as part of the standard update workflow.